### PR TITLE
Make 'React' lowercase

### DIFF
--- a/webpack.build.js
+++ b/webpack.build.js
@@ -24,8 +24,8 @@ module.exports = {
     libraryTarget: 'umd'
   },
   externals: {
-    'react': 'React',
-    'react/addons': 'React'
+    'react': 'react',
+    'react/addons': 'react'
   },
   module: {
     loaders: [


### PR DESCRIPTION
Fixes a warning that occurs in Windows between 'react' and 'React'. 'react' seems to be the 
appropriate convention.

```WARNING in ./~/React/~/fbjs/lib/toArray.js
There is another module with an equal name when case is ignored.
This can lead to unexpected behavior when compiling on a filesystem with other case-semantic.
Rename module if multiple modules are expected or use equal casing if one module is expected.```