### PR TITLE
Put local node_modules/.bin in PATH, fixes #22

### DIFF
--- a/bin/rackt
+++ b/bin/rackt
@@ -25,6 +25,12 @@ cd "`dirname "${SCRIPT_PATH}"`" > /dev/null
 SCRIPT_PATH="`pwd`";
 popd > /dev/null
 
+# put local module binaries first in PATH, to 1) enable the
+# shell scripts to find them, and 2) ensure they are loaded
+# before any other (parent) binaries since npm will put
+# parent node_modules in PATH when run via npm run
+export PATH="${SCRIPT_PATH}/../node_modules/.bin:${PATH}"
+
 # get the path to the task
 TASK_PATH=$SCRIPT_PATH/../tasks/$TASK
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,7 +52,7 @@ module.exports = function(config) {
           {
             test: /\.js$/,
             exclude: /node_modules/,
-            loader: path.resolve(process.env.RACKT_PATH, 'node_modules/babel-loader')
+            loader: 'babel-loader'
           }
         ]
       }

--- a/tasks/build
+++ b/tasks/build
@@ -1,14 +1,12 @@
 #!/bin/bash -e
 
-babel=$RACKT_PATH/node_modules/.bin/babel
-webpack=$RACKT_PATH/node_modules/.bin/webpack
-BUILD="$webpack --devtool source-map --config $RACKT_PATH/webpack.build.js"
+BUILD="webpack --devtool source-map --config $RACKT_PATH/webpack.build.js"
 
 # Clean old build
 rm -rf build/
 
 # Transpile ES6
-$babel -d build/lib ./lib
+babel -d build/lib ./lib
 
 # Generate bundle
 mkdir -p dist

--- a/tasks/init
+++ b/tasks/init
@@ -1,5 +1,3 @@
 #!/bin/bash -e
 
-originate=$RACKT_PATH/node_modules/.bin/originate
-
-$originate react-component $1
+originate react-component $1

--- a/tasks/pages
+++ b/tasks/pages
@@ -20,7 +20,7 @@ git branch -D gh-pages
 git push origin :gh-pages
 
 # build examples
-$RACKT_PATH/node_modules/.bin/webpack --config $RACKT_PATH/webpack.config.js
+webpack --config $RACKT_PATH/webpack.config.js
 
 # remove superfluous files
 find . -type f | egrep -v ".git/|examples/" | xargs rm

--- a/tasks/release
+++ b/tasks/release
@@ -2,7 +2,7 @@
 
 if [ "$1" == "--preview" ] || [ "$1" == "-P" ] || [ "$1" == "-p" ]; then
   # Preview release
-  $RACKT_PATH/node_modules/rf-release/node_modules/.bin/changelog -t preview -s
+  changelog -t preview -s
 else
   # build task has to be run prior to release module
   # the release module is what prompts for next version number
@@ -28,5 +28,5 @@ else
   # Release to npm
   $RACKT_PATH/tasks/build
   update_version 'build/package.json' $next_version
-  $RACKT_PATH/node_modules/.bin/release -v $next_version -f ./build
+  release -v $next_version -f ./build
 fi

--- a/tasks/server
+++ b/tasks/server
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-server=$RACKT_PATH/node_modules/.bin/webpack-dev-server
-
-$server --inline --config $RACKT_PATH/webpack.config.js --content-base examples/ "$@"
+webpack-dev-server --inline --config $RACKT_PATH/webpack.config.js --content-base examples/ "$@"

--- a/tasks/test
+++ b/tasks/test
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-eslint=$RACKT_PATH/node_modules/.bin/eslint
-karma=$RACKT_PATH/node_modules/.bin/karma
-
-$eslint -c $RACKT_PATH/eslint.json lib examples && \
-NODE_ENV=test $karma start $RACKT_PATH/karma.conf.js "$@"
+eslint -c $RACKT_PATH/eslint.json lib examples && \
+NODE_ENV=test karma start $RACKT_PATH/karma.conf.js "$@"

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -33,7 +33,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: path.resolve(process.env.RACKT_PATH, 'node_modules/babel-loader')
+        loader: 'babel-loader'
       }
     ]
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: /node_modules/,
-        loader: path.resolve(process.env.RACKT_PATH, 'node_modules/babel-loader')
+        loader: 'babel-loader'
       }
     ]
   },


### PR DESCRIPTION
A lot of back and forth eventually led to this relatively simple fix. By forcing `rackt-cli/node_modules/.bin` to always be in `PATH` before executing any of the scripts, you don't have to do any manual work trying to figure out where the binaries are located.

This is how it works:
1. For global installs you don't go via npm, so you don't get the automatic module lookup `PATH` it constructs, hence the need to manually put `node_modules/.bin` in `PATH`. Prior to this fix it worked by manually creating paths to the various binaries in `node_modules/.bin`. Now we just reference the binaries indirectly and let the shell figure out where they are by looking in `PATH`. Nothing has changed for global installs.
2. For dependency installs we are in a npm context, so we know the parent `node_modules` dir is in `PATH`, but since we're not running `bin/rackt` via npm ourselves we manually prepend `rackt-cli/node_modules/.bin` to path to ensure that the shell looks there first for binaries, before looking in the parent's `node_modules/.bin`. Prior to this fix we did the same thing as above, but since the dependency paths vary based on sibling dependencies we can't reliably create paths without doing a lot of tedious path traversal. Dependency installs now work on both npm 2 and 3.

I've tried as best I can to test the various scenarios, but any additional testing would be appreciated. I currently only know of one failing case (which also failed prior to this fix): Referencing `bin/rackt` directly when installed as a dependency will fail, due to the parent `node_modules` missing from `PATH`. Using it via `npm run-script` will of course work.