### PR TITLE
Fix karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -62,7 +62,18 @@ module.exports = function(config) {
       stats: {
         colors: true
       }
-    }
+    },
+
+    plugins: [
+      require('karma-webpack'),
+      require('karma-sourcemap-loader'),
+      require('karma-mocha'),
+      require('karma-chrome-launcher'),
+      require('karma-firefox-launcher'),
+      require('karma-ie-launcher'),
+      require('karma-phantomjs-launcher'),
+      require('karma-safari-launcher')
+    ]
   };
 
   tests.forEach(function (test) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "karma-firefox-launcher": "0.1.6",
     "karma-ie-launcher": "0.2.0",
     "karma-mocha": "0.2.0",
-    "karma-phantomjs-launcher": "0.2.1",
+    "karma-phantomjs-launcher": "1.0.1",
     "karma-safari-launcher": "0.1.1",
     "karma-sourcemap-loader": "0.3.6",
     "karma-webpack": "1.7.0",


### PR DESCRIPTION
Fixes problem detailed in #25.

Karma's implicit plugin import apparently doesn't always work, but the workaround was to simply list the plugins explicitly in `karma.conf.js`.

Similarly the `karma-phantomjs-launcher` plugin couldn't find the `phantomjs` module. Turns out the plugin had `phantomjs` listed as a peer-dependency, but `rackt-cli` didn't fullfill this requirement. I don't see how this ever worked, unless the user had `phantomjs` installed globally. The solution was to bump `karma-phantomjs-launcher` to a newer version which has `phantomjs-prebuilt` as a direct dependency.

I successfully ran `npm test` in `react-flipcard` with these changes (after fixing the lint errors).